### PR TITLE
Handle empty credential list when showing credentials

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -69,10 +69,12 @@ def show_creds():
     print("\nEnter domain: ", end="")
     domain = input().strip()
     creds = fc.search(domain_name=domain)
-    if creds:
+    if creds is None:
+        print("❌ Domain not found.\n")
+    elif creds:
         print(f"\nCredentials for domain '{domain}':")
         for cred in creds:
             print(f"  ID: {cred.id} | Login: {cred.login} | Password: {cred.password}")
         print()
     else:
-        print("❌ Domain not found.\n")
+        print(f"❌ No credentials stored for '{domain}'.\n")


### PR DESCRIPTION
## Summary
- fix show_creds so domains with no credentials aren't mistaken for missing

## Testing
- `python -m py_compile cli.py functions.py dbmodels.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_6897536b6e208321bfd322a81dbc82e2